### PR TITLE
changed markdown headings to improve right-hand nav

### DIFF
--- a/samples/05_content_publishers/using_and_updating_GIS_content.ipynb
+++ b/samples/05_content_publishers/using_and_updating_GIS_content.ipynb
@@ -27,9 +27,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.\n",
+      "Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.\n"
+     ]
+    }
+   ],
    "source": [
     "from arcgis.gis import GIS\n",
     "from arcgis.mapping import WebMap, WebScene\n",
@@ -43,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Creating a web map and feature layer\n",
+    "## Creating a web map and feature layer\n",
     "We will will create a feature layer and a web map. We will then delete the feature layer and re-publish. This will change the service and leave us with a broken layer inside our map, don't worry we will fix this in the next steps."
    ]
   },
@@ -110,7 +119,13 @@
    "source": [
     "wm = WebMap()\n",
     "wm.add_layer(capitals_item)\n",
-    "wm.save({\"title\": \"USA Capitals WebMap\", \"tags\": [\"python\", \"webmap\"], \"snippet\": \"A webmap that contains USA capitals as a feature layer.\"})"
+    "wm.save(\n",
+    "    {\n",
+    "        \"title\": \"USA Capitals WebMap\", \n",
+    "        \"tags\": [\"python\", \"webmap\"], \n",
+    "        \"snippet\": \"A webmap that contains USA capitals as a feature layer.\"\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -175,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using and updating a web map\n",
+    "## Using and updating a web map\n",
     "We will search for that web map that has broken layers, render it on the notebook and update it."
    ]
   },
@@ -233,7 +248,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fix errors in web map\n",
+    "### Fix errors in web map\n",
     "The widget loads an empty web map with just a basemap. Let us investigate the contents of the web map to determine the issue. You can query the layers in the web map using the `layers` property."
    ]
   },
@@ -513,7 +528,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Update the web map\n",
+    "### Update the web map\n",
     "Now the web map should be fixed as it points to a live service. To update the web map, we call the `update()` method. You have the option to update the thumbnail or any other item properties at this time."
    ]
   },
@@ -591,7 +606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using and updating a web scene\n",
+    "## Using and updating a web scene\n",
     "In the sample above we observed how to update a web map. Updating the web scene is similar, we use the `update()` method. Let us look at the example of a web scene that displays tropical cyclones over the Pacific ocean."
    ]
   },
@@ -682,7 +697,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make a copy of the public web scene item\n",
+    "### Make a copy of the public web scene item\n",
     "To make a copy, we essentially download the content of the web scene JSON, remove the parts we don't want, add the layers that we want and publish a new item using that information. The publishing steps are similar to what is described earlier in the **data preparation** section and in detail in the sample titled **Publishing web maps and web scenes**.\n",
     "\n",
     "Let's say, we are only interested in the storms that occur in summer. Summer in tropical Asia is around April-June and that matches with a layer in the existing web scene. Let us query the `operationalLayers` section of the web scene to understand what  the layers look like.\n",
@@ -1955,7 +1970,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Summary\n",
+    "## Summary\n",
     "In this sample, we observed how to consume web maps, web scenes and how to update them. During this process, the sample showed how to read a web feature layers, how to use geocoding to get co-ordinates of a point of interest, how to modify the map widget using code, how to make copy of an existing item into your account, how to look for basemaps and finally, how to update layer properties within a web scene."
    ]
   }
@@ -1981,7 +1996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.9"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Hi @tarunkukreja003 

* I submitted a PR to:
  * change the markdown headings for the cells so that the right-hand navigation of the guide is aligned with notebook, it's incorrect in production 

![image](https://github.com/tarunkukreja003/arcgis-python-api-fork/assets/1399179/77ab9034-8dbd-4616-829c-f737aaff6fc4)

  * updated the format of the parameters in a method so that it was easier to view instead of having so scroll off the page

![image](https://github.com/tarunkukreja003/arcgis-python-api-fork/assets/1399179/d0a817eb-e33c-4399-8fce-e051b3e1d93f)
